### PR TITLE
Add Handle::set_status method

### DIFF
--- a/src/handle.rs
+++ b/src/handle.rs
@@ -196,4 +196,17 @@ impl Handle {
             )),
         }
     }
+
+    /// Set the audit status
+    ///
+    /// You must have properly set the mask field according to which fields
+    /// must be set.
+    pub async fn set_status(
+        &mut self,
+        status: StatusMessage,
+    ) -> Result<(), Error> {
+        let mut req = NetlinkMessage::from(AuditMessage::SetStatus(status));
+        req.header.flags = NLM_F_REQUEST | NLM_F_ACK;
+        self.acked_request(req).await
+    }
 }


### PR DESCRIPTION
Hello.

First of all, thanks for this crate. I've started using it and there are a few changes that I would like to upstream. First one is a simple method to set the status, which mirrors the get status one.